### PR TITLE
fix: Ensure that the enrolment CA is selected when the DMS is created.

### DIFF
--- a/src/views/DMS/DMSCreateUpdate.tsx
+++ b/src/views/DMS/DMSCreateUpdate.tsx
@@ -321,6 +321,10 @@ export const DMSForm: React.FC<Props> = ({ dms, onSubmit, actionLabel = "Create"
     }
 
     const submit = handleSubmit(data => {
+        if (!data.enrollProtocol.enrollmentCA) {
+            enqueueSnackbar("Enrollment CA is required", { variant: "error" });
+            return;
+        }
         const run = async () => {
             let awsMeta = {};
             if (data.awsIotIntegration.id !== "") {


### PR DESCRIPTION
This PR adds a presubmit control that ensures that a enrollment CA has been selected. This avoid a server error on submit.