### PR TITLE
Fix csr cn generation using utf8 encoding

### DIFF
--- a/src/utils/crypto/csr.ts
+++ b/src/utils/crypto/csr.ts
@@ -53,7 +53,7 @@ export const createCSR = async (keyPair: CryptoKeyPair, hashAlg: "SHA-1" | "SHA-
         if (subjectProps[key]) {
             pkcs10.subject.typesAndValues.push(new pkijs.AttributeTypeAndValue({
                 type: key,
-                value: new asn1js.PrintableString({ value: subjectProps[key] })
+                value: new asn1js.Utf8String({ value: subjectProps[key] })
             }));
         }
     }

--- a/src/views/CAs/IssuedCertificates.tsx
+++ b/src/views/CAs/IssuedCertificates.tsx
@@ -22,6 +22,7 @@ import PublishIcon from "@mui/icons-material/Publish";
 import React, { useEffect, useState } from "react";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import apicalls from "ducks/apicalls";
+import { errorToString } from "ducks/services/api-client";
 
 const queryableFields = [
     { key: "subject.common_name", title: "Common Name", operator: "contains" },
@@ -64,8 +65,12 @@ export const IssuedCertificates: React.FC<Props> = ({ caData }) => {
         component: (
             <CSRInBrowserGenerator onCreate={async (key, csr) => {
                 setImportSignStatus({ loading: true, errMessage: "", response: undefined });
-                const singResp = await apicalls.cas.signCertificateRequest(caData.id, window.window.btoa(csr));
-                setImportSignStatus({ loading: false, errMessage: "", response: singResp });
+                try {
+                    const singResp = await apicalls.cas.signCertificateRequest(caData.id, window.window.btoa(csr));
+                    setImportSignStatus({ loading: false, errMessage: "", response: singResp });
+                } catch (error: any) {
+                    setImportSignStatus({ loading: false, errMessage: errorToString(error), response: undefined });
+                }
             }} />
         )
     }, {
@@ -289,7 +294,17 @@ export const IssuedCertificates: React.FC<Props> = ({ caData }) => {
                                                     ? (
                                                         importSignStatus.errMessage !== ""
                                                             ? (
-                                                                <>{importSignStatus.errMessage}</>
+                                                                <Grid container spacing={2}>
+                                                                    <Grid xs={12}>
+                                                                        <Alert severity="error" action={
+                                                                            <Button variant="contained" color="error" size="small" onClick={() => { resetAddCertificate(); setDisplayIssueCert(false); }}>
+                                                                        Go Back
+                                                                            </Button>
+                                                                        }>
+                                                                            {importSignStatus.errMessage}
+                                                                        </Alert>
+                                                                    </Grid>
+                                                                </Grid>
                                                             )
                                                             : (
                                                                 importSignStatus.response !== undefined


### PR DESCRIPTION
This pull request includes changes to improve error handling and string encoding in the certificate signing request (CSR) process and the user interface for issued certificates. The most important changes include updating the string encoding method, adding error handling for certificate signing, and enhancing the user interface to display error messages more effectively.

Improvements to string encoding and error handling:

* [`src/utils/crypto/csr.ts`](diffhunk://#diff-74a32104a6e1a28876138a570c170a1f6390bd2b606d8cc5ff7e6cf2a26d7180L56-R56): Changed the encoding of `subjectProps` values from `PrintableString` to `Utf8String` to support a wider range of characters.

Enhancements to error handling and user interface:

* [`src/views/CAs/IssuedCertificates.tsx`](diffhunk://#diff-8f646641ec0dcc2fcff713f85ab8a9f75da84d21e1fd65fda5ff2324b4c6438fR25): Imported `errorToString` utility to convert errors to user-friendly messages.
* [`src/views/CAs/IssuedCertificates.tsx`](diffhunk://#diff-8f646641ec0dcc2fcff713f85ab8a9f75da84d21e1fd65fda5ff2324b4c6438fR68-R73): Added a try-catch block to handle errors during the certificate signing request and display appropriate error messages.
* [`src/views/CAs/IssuedCertificates.tsx`](diffhunk://#diff-8f646641ec0dcc2fcff713f85ab8a9f75da84d21e1fd65fda5ff2324b4c6438fL292-R307): Enhanced the UI to display error messages within an `Alert` component and provided a "Go Back" button for better user experience.

addreses and fixes #40 