### PR TITLE
Feat: Update CRL download from CAID to KeyID

### DIFF
--- a/src/components/forms/Expiration.tsx
+++ b/src/components/forms/Expiration.tsx
@@ -1,6 +1,6 @@
 import { Control, Controller, FieldPath, FieldValues, useForm } from "react-hook-form";
 import Grid from "@mui/material/Unstable_Grid2";
-import React, { useEffect } from "react";
+import React from "react";
 import { FormSelect } from "./Select";
 import { Moment } from "moment";
 import { validDurationRegex } from "utils/duration";
@@ -47,9 +47,12 @@ export const ExpirationInput = (props: ExpirationInputProps) => {
 
     const watchAll = watch();
 
-    useEffect(() => {
-        props.onChange(watchAll);
-    }, [watchAll]);
+    React.useEffect(() => {
+        const subscription = watch((value, { name, type }) => {
+            props.onChange(value as FormData);
+        });
+        return () => subscription.unsubscribe();
+    }, [watch]);
 
     return (
         <Grid container spacing={2} alignItems={"end"}>

--- a/src/views/CAs/CAInspector.tsx
+++ b/src/views/CAs/CAInspector.tsx
@@ -147,7 +147,7 @@ export const CAInspector: React.FC<Props> = ({ caName, engines }) => {
                                             <LoadingButton loading={loadingCRLResp} onClick={async () => {
                                                 setLoadingCRLResp(true);
                                                 try {
-                                                    const crl = await apicalls.va.getCRL(caData.id);
+                                                    const crl = await apicalls.va.getCRL(caData.certificate.key_id);
                                                     download(`${caData.certificate.subject.common_name}.crl`, crl);
                                                 } catch (e) {
                                                     enqueueSnackbar(`Error while downloading CRL for CA with ID ${caData.id} and CN ${caData.certificate.subject.common_name}: ${e}`, { variant: "error" });


### PR DESCRIPTION
This pull request includes changes to the `src/components/forms/Expiration.tsx` and `src/views/CAs/CAInspector.tsx` files to improve the handling of form state and correct the retrieval of certificate revocation lists (CRLs). The most important changes include replacing the use of `useEffect` with `React.useEffect` for better subscription management and fixing the key used to fetch CRLs.

Improvements to form state handling:

* [`src/components/forms/Expiration.tsx`](diffhunk://#diff-0adcfb861a254a1c5769b9890817bc0b82b628341b47e17da1d6e69139cbd4f8L50-R55): Replaced `useEffect` with `React.useEffect` to manage form state subscriptions more effectively. This change ensures that the form state is properly updated and cleaned up.

Bug fixes:

* [`src/views/CAs/CAInspector.tsx`](diffhunk://#diff-ef8b1b46e3e8bb5ebeffb48e43601832dc4266f9ce1693eb65e8e7d5c08a085cL150-R150): Corrected the key used to fetch CRLs by changing `caData.id` to `caData.certificate.key_id`. This fixes an issue where the wrong key was being used, potentially leading to errors in CRL retrieval.