### PR TITLE
Improved ImportCA to update level based on DSN and KID

### DIFF
--- a/src/views/CAs/CAImporter.tsx
+++ b/src/views/CAs/CAImporter.tsx
@@ -1,5 +1,4 @@
 import { Alert, Typography, useTheme } from "@mui/material";
-import { CASelector } from "components/CAs/CASelector";
 import { CATimeline } from "./CATimeline";
 import { CertificateAuthority, CryptoEngine, ExpirationFormat } from "ducks/features/cas/models";
 import { FormTextField } from "components/forms/Textfield";
@@ -109,17 +108,6 @@ export const CAImporter: React.FC<CAImporterProps> = ({ defaultEngine }) => {
 
             <Grid xs={12} >
                 <FormTextField label="CA ID" name={"id"} control={control} disabled />
-            </Grid>
-            <Grid xs={12} >
-                <CASelector
-                    value={getValues("parentCA")}
-                    onSelect={(elems) => {
-                        if (!Array.isArray(elems)) {
-                            setValue("parentCA", elems);
-                        }
-                    }}
-                    multiple={false} label="Parent CA"
-                />
             </Grid>
             <Grid xs={12}>
                 <CertificateImporter onChange={async (crt) => {


### PR DESCRIPTION
This pull request includes changes to the `CAImporter` component in the `src/views/CAs/CAImporter.tsx` file. The most important changes involve the removal of the `CASelector` import and its associated JSX element, which simplifies the component.

Codebase simplification:

* [`src/views/CAs/CAImporter.tsx`](diffhunk://#diff-944308185094bacee96316cab7f363385b605239477a2c41f244ca6b5d898802L2): Removed the import statement for `CASelector` as it is no longer used in the component.
* [`src/views/CAs/CAImporter.tsx`](diffhunk://#diff-944308185094bacee96316cab7f363385b605239477a2c41f244ca6b5d898802L113-L123): Removed the `CASelector` JSX element from the `CAImporter` component, including its associated props and event handlers.