### PR TITLE
Fix: Allow deleting CA when certificate is expired or revoked

### DIFF
--- a/src/views/CAs/CAInspector.tsx
+++ b/src/views/CAs/CAInspector.tsx
@@ -153,14 +153,14 @@ export const CAInspector: React.FC<Props> = ({ caName, engines }) => {
                                                     enqueueSnackbar(`Error while downloading CRL for CA with ID ${caData.id} and CN ${caData.certificate.subject.common_name}: ${e}`, { variant: "error" });
                                                 }
                                                 setLoadingCRLResp(false);
-                                            }} style={{ background: lighten(theme.palette.primary.main, 0.7) }} endIcon={ <FileDownloadRoundedIcon fontSize={"small"} />}>
+                                            }} style={{ background: lighten(theme.palette.primary.main, 0.7) }} endIcon={<FileDownloadRoundedIcon fontSize={"small"} />}>
                                                 CRL
                                             </LoadingButton>
                                         </Tooltip >
                                     </Grid>
 
                                     {
-                                        (caData.certificate.type !== "EXTERNAL" && caData.certificate.status !== CertificateStatus.Revoked) && (
+                                        (caData.certificate.type !== "EXTERNAL" && caData.certificate.status === CertificateStatus.Active) && (
                                             <Grid xs="auto">
                                                 <Tooltip title="Revoke CA">
                                                     <IconButton onClick={() => setRevokeDialog(caData)} style={{ background: lighten(theme.palette.error.main, 0.7) }}>
@@ -171,7 +171,10 @@ export const CAInspector: React.FC<Props> = ({ caName, engines }) => {
                                         )
                                     }
                                     {
-                                        ((caData.certificate.type !== "EXTERNAL" && caData.certificate.status === CertificateStatus.Revoked) || (caData.certificate.type === "EXTERNAL")) && (
+                                        (
+                                            (caData.certificate.type !== "EXTERNAL" && caData.certificate.status !== CertificateStatus.Active) ||
+                                            (caData.certificate.type === "EXTERNAL")
+                                        ) && (
                                             <Grid xs="auto">
                                                 <Button variant="contained" color="error" onClick={async () => {
                                                     try {

--- a/src/views/CAs/CAInspector.tsx
+++ b/src/views/CAs/CAInspector.tsx
@@ -172,9 +172,7 @@ export const CAInspector: React.FC<Props> = ({ caName, engines }) => {
                                     }
                                     {
                                         (
-                                            (caData.certificate.type !== "EXTERNAL" && caData.certificate.status !== CertificateStatus.Active) ||
-                                            (caData.certificate.type === "EXTERNAL")
-                                        ) && (
+                                            (caData.certificate.type === "EXTERNAL" || caData.certificate.status !== CertificateStatus.Active)) && (
                                             <Grid xs="auto">
                                                 <Button variant="contained" color="error" onClick={async () => {
                                                     try {


### PR DESCRIPTION
This pull request includes changes to the `CAInspector` component in `src/views/CAs/CAInspector.tsx` to improve the handling of certificate statuses. The main focus is on adjusting the conditions for displaying certain UI elements based on the certificate type and status.

Changes to UI element conditions:

* Updated the condition to display the "Revoke CA" button to check if the certificate status is `Active` instead of not being `Revoked`.
* Refactored the condition to display a specific `Button` element to handle cases where the certificate is not `Active` or is of type `EXTERNAL`.