### PR TITLE
fix: show device details only when identity is not null

### DIFF
--- a/src/views/Devices/ViewDevice.tsx
+++ b/src/views/Devices/ViewDevice.tsx
@@ -82,6 +82,11 @@ export const ViewDevice: React.FC<Props> = () => {
         return deviceActions;
     };
 
+    const showDetails = (device: Device) => {
+        const { status, identity } = device;
+        return status !== DeviceStatus.NoIdentity && identity;
+    };
+
     return (
         <FetchViewer ref={ref} fetcher={() => apicalls.devices.getDeviceByID(params.deviceId!)} renderer={device => {
             return (
@@ -139,7 +144,7 @@ export const ViewDevice: React.FC<Props> = () => {
 
                     <Grid>
                         {
-                            device.status !== DeviceStatus.NoIdentity && (
+                            showDetails(device) && (
                                 <ViewDeviceDetails device={device} onChange={() => {
                                     ref.current?.refresh();
                                 }} />


### PR DESCRIPTION
This PR fixes an issue that happens after decommissioning a device with no identity. When visiting a decommissioned device with no identity (`ViewDevice` component)  the `ViewDeviceDetails` component is rendered inside it. Because the device has no identity an undefined error is raised in the JavaScript console and the browser page remains blank. 

The proposed solution adds an extra condition to check that the device has identity in order to show it's details.