### PR TITLE
feat: enable DMS delete operation

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -8,7 +8,8 @@ interface SelectProps extends MuiSelectProps {
     label: string
     options: Array<{
         value: any,
-        render: string | (() => React.ReactElement)
+        render: string | (() => React.ReactElement),
+        disabled?: boolean
     }>
 }
 
@@ -30,7 +31,7 @@ const Select: React.FC<SelectProps> = ({ ...rest }) => {
                     )
                     : (
                         rest.options.map((option) => (
-                            <MenuItem key={option.value} value={option.value}>
+                            <MenuItem key={option.value} value={option.value} disabled={option.disabled}>
                                 {typeof option.render === "string" ? option.render : option.render()}
                             </MenuItem>
                         ))

--- a/src/ducks/features/dmss/apicalls.ts
+++ b/src/ducks/features/dmss/apicalls.ts
@@ -45,6 +45,13 @@ export const updateDMS = async (id: string, payload: CreateUpdateDMSPayload): Pr
     }) as Promise<DMS>;
 };
 
+export const deleteDMS = async (id: string): Promise<{}> => {
+    return apiRequest({
+        method: "DELETE",
+        url: `${window._env_.LAMASSU_DMS_MANAGER_API}/v1/dms/${id}`
+    }) as Promise<{}>;
+};
+
 export const bindDeviceIdentity = async (device_id: string, cert_sn: string): Promise<BindResponse> => {
     return apiRequest({
         method: "POST",

--- a/src/views/DMS/DMSList.tsx
+++ b/src/views/DMS/DMSList.tsx
@@ -475,7 +475,22 @@ const DMSCardRenderer: React.FC<DMSCardRendererProps> = ({ dms, onDelete, engine
                                     </Typography>
                                 </Grid>
                                 <Grid xs={12}>
-                                    <Select label="Delete Mode" options={deleteTypes} />
+                                    <Select label="Delete Mode" value="SOFT-DELETE" options={[
+                                        {
+                                            value: "SOFT-DELETE",
+                                            render: "Detach Devices"
+                                        },
+                                        {
+                                            value: "CHAINED-DELETE",
+                                            render: "Delete owned Devices",
+                                            disabled: true
+                                        },
+                                        {
+                                            value: "TRANSFER",
+                                            render: "Transfer owned Devices to DMS",
+                                            disabled: true
+                                        }
+                                    ]} />
                                 </Grid>
                             </Grid>
                         )}

--- a/src/views/DMS/DMSList.tsx
+++ b/src/views/DMS/DMSList.tsx
@@ -373,8 +373,10 @@ const DMSCardRenderer: React.FC<DMSCardRendererProps> = ({ dms, onDelete, engine
                                 </MenuItem>
 
                                 <Divider sx={{ my: 0.5 }} />
-
-                                <MenuItem disabled onClick={handleClickMenuDelete} disableRipple>
+                                <MenuItem onClick={() => {
+                                    handleClose();
+                                    setShowDelete(true);
+                                }} disableRipple>
                                     <DeleteIcon fontSize={"small"} sx={{ color: theme.palette.error.main, marginRight: "10px" }} />
                                     Delete
                                 </MenuItem>
@@ -480,7 +482,16 @@ const DMSCardRenderer: React.FC<DMSCardRendererProps> = ({ dms, onDelete, engine
                         actions={
                             <Grid container spacing={1}>
                                 <Grid xs>
-                                    <Button fullWidth color="error" variant="contained" onClick={handleClickDelete}>Delete</Button>
+                                    <Button fullWidth color="error" variant="contained" onClick={async () => {
+                                        try {
+                                            await apicalls.dmss.deleteDMS(dms.id);
+                                            enqueueSnackbar(`DMS ${dms.id} deleted successfully`, { variant: "success" });
+                                            setShowDelete(false);
+                                            onDelete();
+                                        } catch (e) {
+                                            enqueueSnackbar(`Error deleting DMS ${dms.id}: ${errorToString(e)}`, { variant: "error" });
+                                        }
+                                    }}>Delete</Button>
                                 </Grid>
                                 <Grid xs="auto">
                                     <Button variant="text" onClick={() => setShowDelete(false)}>Close</Button>


### PR DESCRIPTION
This pull request enables the DMS delete operation. This implementation only allows performing a soft delete, that is, only the DMS will be deleted keeping it's owned devices orphan.

![image](https://github.com/user-attachments/assets/9ce3ccf6-1f35-4948-bc6c-be912e49bb32)


This PR aligns the UI behaviour with the backend lamassuiot/lamassuiot#252.