### PR TITLE
chore: Set vite to a minimum version of 6.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "keycloak-js": "^26.1.4",
                 "moment": "^2.30.1",
                 "notistack": "^3.0.1",
+                "oidc-client-ts": "^3.2.1",
                 "pkijs": "^3.0.16",
                 "process": "^0.11.10",
                 "pvtsutils": "^1.3.5",
@@ -81,7 +82,7 @@
                 "eslint-plugin-react-hooks": "4.6.2",
                 "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
                 "eslint-plugin-unused-imports": "^2.0.0",
-                "vite": "^6.2.2",
+                "vite": "^6.2.7",
                 "vite-plugin-eslint": "^1.8.1"
             }
         },
@@ -8918,6 +8919,14 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/jwt-decode": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+            "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/keyborg": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.6.0.tgz",
@@ -9388,6 +9397,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/oidc-client-ts": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.2.1.tgz",
+            "integrity": "sha512-hS5AJ5s/x4bXhHvNJT1v+GGvzHUwdRWqNQQbSrp10L1IRmzfRGKQ3VWN3dstJb+oF3WtAyKezwD2+dTEIyBiAA==",
+            "dependencies": {
+                "jwt-decode": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/once": {
@@ -11310,6 +11330,48 @@
                 "node": "*"
             }
         },
+        "node_modules/tinyglobby": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "dev": true,
+            "dependencies": {
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.4.5",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+            "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+            "dev": true,
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -11601,15 +11663,17 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-            "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+            "version": "6.3.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2",
                 "postcss": "^8.5.3",
-                "rollup": "^4.30.1"
+                "rollup": "^4.34.9",
+                "tinyglobby": "^0.2.13"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -11686,6 +11750,32 @@
             "peerDependencies": {
                 "eslint": ">=7",
                 "vite": ">=2"
+            }
+        },
+        "node_modules/vite/node_modules/fdir": {
+            "version": "6.4.5",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+            "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+            "dev": true,
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/vite/node_modules/rollup": {
@@ -17117,6 +17207,7 @@
                 "keycloak-js": "^26.1.4",
                 "moment": "^2.30.1",
                 "notistack": "^3.0.1",
+                "oidc-client-ts": "^3.2.1",
                 "pkijs": "^3.0.16",
                 "process": "^0.11.10",
                 "pvtsutils": "^1.3.5",
@@ -17133,7 +17224,7 @@
                 "react-spinners": "^0.15.0",
                 "react-syntax-highlighter": "^15.5.0",
                 "typescript": "^4.9.5",
-                "vite": "^6.2.2",
+                "vite": "^6.2.7",
                 "vite-plugin-eslint": "^1.8.1",
                 "web-vitals": "^2.1.4"
             },
@@ -23106,6 +23197,11 @@
                         "object.values": "^1.1.6"
                     }
                 },
+                "jwt-decode": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+                    "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
+                },
                 "keyborg": {
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.6.0.tgz",
@@ -23435,6 +23531,14 @@
                         "call-bind": "^1.0.7",
                         "define-properties": "^1.2.1",
                         "es-object-atoms": "^1.0.0"
+                    }
+                },
+                "oidc-client-ts": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.2.1.tgz",
+                    "integrity": "sha512-hS5AJ5s/x4bXhHvNJT1v+GGvzHUwdRWqNQQbSrp10L1IRmzfRGKQ3VWN3dstJb+oF3WtAyKezwD2+dTEIyBiAA==",
+                    "requires": {
+                        "jwt-decode": "^4.0.0"
                     }
                 },
                 "once": {
@@ -24755,6 +24859,31 @@
                     "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
                     "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
                 },
+                "tinyglobby": {
+                    "version": "0.2.14",
+                    "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+                    "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+                    "dev": true,
+                    "requires": {
+                        "fdir": "^6.4.4",
+                        "picomatch": "^4.0.2"
+                    },
+                    "dependencies": {
+                        "fdir": {
+                            "version": "6.4.5",
+                            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+                            "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+                            "dev": true,
+                            "requires": {}
+                        },
+                        "picomatch": {
+                            "version": "4.0.2",
+                            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+                            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+                            "dev": true
+                        }
+                    }
+                },
                 "to-regex-range": {
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -24963,17 +25092,33 @@
                     "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 },
                 "vite": {
-                    "version": "6.2.2",
-                    "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-                    "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+                    "version": "6.3.5",
+                    "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+                    "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
                     "dev": true,
                     "requires": {
                         "esbuild": "^0.25.0",
+                        "fdir": "^6.4.4",
                         "fsevents": "~2.3.3",
+                        "picomatch": "^4.0.2",
                         "postcss": "^8.5.3",
-                        "rollup": "^4.30.1"
+                        "rollup": "^4.34.9",
+                        "tinyglobby": "^0.2.13"
                     },
                     "dependencies": {
+                        "fdir": {
+                            "version": "6.4.5",
+                            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+                            "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+                            "dev": true,
+                            "requires": {}
+                        },
+                        "picomatch": {
+                            "version": "4.0.2",
+                            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+                            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+                            "dev": true
+                        },
                         "rollup": {
                             "version": "4.37.0",
                             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
@@ -25899,6 +26044,11 @@
                 "object.values": "^1.1.6"
             }
         },
+        "jwt-decode": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+            "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
+        },
         "keyborg": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.6.0.tgz",
@@ -26228,6 +26378,14 @@
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
                 "es-object-atoms": "^1.0.0"
+            }
+        },
+        "oidc-client-ts": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.2.1.tgz",
+            "integrity": "sha512-hS5AJ5s/x4bXhHvNJT1v+GGvzHUwdRWqNQQbSrp10L1IRmzfRGKQ3VWN3dstJb+oF3WtAyKezwD2+dTEIyBiAA==",
+            "requires": {
+                "jwt-decode": "^4.0.0"
             }
         },
         "once": {
@@ -27548,6 +27706,31 @@
             "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
             "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
         },
+        "tinyglobby": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "dev": true,
+            "requires": {
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2"
+            },
+            "dependencies": {
+                "fdir": {
+                    "version": "6.4.5",
+                    "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+                    "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+                    "dev": true,
+                    "requires": {}
+                },
+                "picomatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+                    "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+                    "dev": true
+                }
+            }
+        },
         "to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -27756,17 +27939,33 @@
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "vite": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-            "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+            "version": "6.3.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
             "dev": true,
             "requires": {
                 "esbuild": "^0.25.0",
+                "fdir": "^6.4.4",
                 "fsevents": "~2.3.3",
+                "picomatch": "^4.0.2",
                 "postcss": "^8.5.3",
-                "rollup": "^4.30.1"
+                "rollup": "^4.34.9",
+                "tinyglobby": "^0.2.13"
             },
             "dependencies": {
+                "fdir": {
+                    "version": "6.4.5",
+                    "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+                    "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+                    "dev": true,
+                    "requires": {}
+                },
+                "picomatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+                    "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+                    "dev": true
+                },
                 "rollup": {
                     "version": "4.37.0",
                     "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "eslint-plugin-react-hooks": "4.6.2",
         "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
         "eslint-plugin-unused-imports": "^2.0.0",
-        "vite": "^6.2.2",
+        "vite": "^6.2.7",
         "vite-plugin-eslint": "^1.8.1"
     },
     "scripts": {


### PR DESCRIPTION
This pull request makes minor dependency updates. These changes aim to modernize the environment and improve compatibility with newer tools and libraries.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L81-R81): Upgraded the `vite` dependency from version `^6.2.2` to `^6.2.7`.
