### PR TITLE
ci: Update actions

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
 
 jobs:
   dev_image:
@@ -11,19 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       
       - name: Login to Github Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v3 
         with:
             registry: ghcr.io
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build the Docker image latest tag
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,17 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:        
     - name: Login to Github Registry
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v3
       with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
 
     - name: Build Docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         context: .
         build-args: |
@@ -38,7 +38,7 @@ jobs:
         push: true
       
     - name: Create tag
-      uses: actions/github-script@v5
+      uses: actions/github-script@v7
       with:
         script: |
           github.rest.git.createRef({


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest versions of actions and adds a new trigger for manual workflow dispatch. These changes improve maintainability and compatibility with the latest features of the respective actions.

### Workflow updates:

* [`.github/workflows/develop.yml`](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbR7-R27): Added `workflow_dispatch` to enable manual triggering of the workflow.
* [`.github/workflows/develop.yml`](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbR7-R27): Updated `actions/checkout` from `v2` to `v4`, `docker/login-action` from `v1` to `v3`, and `docker/build-push-action` from `v2` to `v6`.

### Workflow version upgrades:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L19-R29): Updated `docker/login-action` from `v1` to `v3`, `actions/checkout` from `master` to `v4`, and `docker/build-push-action` from `v2` to `v6`.
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L41-R41): Updated `actions/github-script` from `v5` to `v7` for the "Create tag" step.