### PR TITLE
ci: generate dummy env file for build

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -22,6 +22,21 @@ jobs:
             registry: ghcr.io
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Generate dummy env-config.js from template
+        run: |
+          cp env-docker-config.js env-config.js
+          sed -i 's/${CHART_VERSION}/dummy_chart_version/g' env-config.js
+          sed -i 's/${HELM_REVISION}/dummy_helm_revision/g' env-config.js
+          sed -i 's/${OIDC_ENABLED}/false/g' env-config.js
+          sed -i 's/${COGNITO_ENABLED}/false/g' env-config.js
+          sed -i 's/${COGNITO_HOSTED_UI_DOMAIN}/dummy_cognito_hosted_ui_domain/g' env-config.js
+          sed -i 's/${OIDC_AUTHORITY}/dummy_oidc_authority/g' env-config.js
+          sed -i 's/${OIDC_CLIENT_ID}/dummy_oidc_client_id/g' env-config.js
+          sed -i 's/${DOMAIN}/dummy_domain/g' env-config.js
+          sed -i 's/$CLOUD_CONNECTORS/[]/g' env-config.js
+          echo "env-config.js generated with dummy values"
+          cat env-config.js
 
       - name: Build the Docker image latest tag
         uses: docker/build-push-action@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,21 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Generate dummy env-config.js from template
+      run: |
+        cp env-docker-config.js env-config.js
+        sed -i 's/${CHART_VERSION}/dummy_chart_version/g' env-config.js
+        sed -i 's/${HELM_REVISION}/dummy_helm_revision/g' env-config.js
+        sed -i 's/${OIDC_ENABLED}/false/g' env-config.js
+        sed -i 's/${COGNITO_ENABLED}/false/g' env-config.js
+        sed -i 's/${COGNITO_HOSTED_UI_DOMAIN}/dummy_cognito_hosted_ui_domain/g' env-config.js
+        sed -i 's/${OIDC_AUTHORITY}/dummy_oidc_authority/g' env-config.js
+        sed -i 's/${OIDC_CLIENT_ID}/dummy_oidc_client_id/g' env-config.js
+        sed -i 's/${DOMAIN}/dummy_domain/g' env-config.js
+        sed -i 's/$CLOUD_CONNECTORS/[]/g' env-config.js
+        echo "env-config.js generated with dummy values"
+        cat env-config.js
+
     - name: Build Docker image
       uses: docker/build-push-action@v6
       with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to include a step for generating a dummy `env-config.js` file during the build process. This ensures that the workflows can proceed without requiring sensitive or environment-specific values.

### Workflow updates:

* **`.github/workflows/develop.yml`**: Added a step to generate a dummy `env-config.js` file from the `env-docker-config.js` template. This involves replacing placeholders with dummy values, such as `dummy_chart_version`, `dummy_oidc_client_id`, and others.
* **`.github/workflows/main.yml`**: Similarly, added a step to generate a dummy `env-config.js` file in the main workflow, ensuring consistency across workflows.