### PR TITLE
fix: CA Selector: Remove extra = from the CAs request filter

### DIFF
--- a/src/components/CAs/CASelector.tsx
+++ b/src/components/CAs/CASelector.tsx
@@ -27,7 +27,7 @@ export const CASelector: React.FC<Props> = (props: Props) => {
                         let params: QueryParameters | undefined;
                         if (query !== "") {
                             params = {
-                                filters: [`id=[contains]${query}`]
+                                filters: [`id[contains]${query}`]
                             };
                         }
                         const resp = await apicalls.cas.getCAs(params);


### PR DESCRIPTION
Fixes an issue where an extra "=" character was included in the CAs request filter, which could lead to incorrect query behavior.

This pull request includes a minor fix to the `CASelector` component in the `src/components/CAs/CASelector.tsx` file. The change corrects the syntax of a filter string in the query parameters.

* [`src/components/CAs/CASelector.tsx`](diffhunk://#diff-78351b4dc89b96a77efffeca6b931307f9aa3503c66e92021408810a0f55f1b0L30-R30): Fixed the filter string syntax in the `params` object by removing the unnecessary `=` character, changing `id=[contains]${query}` to `id[contains]${query}`.