### PR TITLE
fix: refresh CA stats when CA data changes

### DIFF
--- a/src/views/CAs/CAInspector.tsx
+++ b/src/views/CAs/CAInspector.tsx
@@ -261,11 +261,12 @@ export const CAInspector: React.FC = () => {
                         {
                             caData.certificate.type !== "EXTERNAL" && (
                                 <FetchViewer
+                                    key={caData.id}
                                     fetcher={() => apicalls.cas.getStatsByCA(caName)}
                                     renderer={(caStats) => {
-                                        const statsActive = caStats[CertificateStatus.Active] ? caStats[CertificateStatus.Active] : 0;
-                                        const statsRevoked = caStats[CertificateStatus.Revoked] ? caStats[CertificateStatus.Revoked] : 0;
-                                        const statsExpired = caStats[CertificateStatus.Expired] ? caStats[CertificateStatus.Expired] : 0;
+                                        const statsActive = caStats[CertificateStatus.Active] ?? 0;
+                                        const statsRevoked = caStats[CertificateStatus.Revoked] ?? 0;
+                                        const statsExpired = caStats[CertificateStatus.Expired] ?? 0;
 
                                         const totalCerts = statsActive + statsExpired + statsRevoked;
                                         if (totalCerts === 0) {


### PR DESCRIPTION
This pull request forces an update of the CA stats when the user navigates from one CA to another because otherwise the stats showed are not in sync.

Fixes #91 